### PR TITLE
docs: add tsdoc comments

### DIFF
--- a/src/chains/introAnswer.ts
+++ b/src/chains/introAnswer.ts
@@ -14,7 +14,12 @@ import { LlmCaps } from "../services/llm.js";
 const OLLAMA = process.env.OLLAMA_URL || "http://127.0.0.1:11434";
 const CHAT_MODEL = process.env.CHAT_MODEL || "mistral:7b-instruct-q4_K_M";
 
-/** Remove dataset-y labels or bullets the model might echo. */
+/**
+ * Remove dataset-y labels or bullets the model might echo.
+ *
+ * @param s - Raw model output.
+ * @returns Cleaned text string.
+ */
 function sanitize(s: string): string {
   return s
     .replace(
@@ -26,13 +31,25 @@ function sanitize(s: string): string {
     .trim();
 }
 
-/** Cap to N sentences. */
+/**
+ * Clamp text to the first N sentences.
+ *
+ * @param s - Input text.
+ * @param n - Maximum number of sentences to keep.
+ * @returns Truncated string.
+ */
 function firstNSentences(s: string, n: number): string {
   const parts = s.replace(/\s+/g, " ").split(/(?<=[.!?])\s/);
   return parts.slice(0, n).join(" ").trim();
 }
 
-/** Extract first JSON object from a string (tolerates extra prose). */
+/**
+ * Extract the first JSON object found in a string.
+ * Tolerates extra prose before or after the JSON.
+ *
+ * @param text - Source text possibly containing JSON.
+ * @returns Parsed object or `null` if none.
+ */
 function extractFirstJson(text: string): any | null {
   const m = text.match(/\{[\s\S]*\}/);
   if (!m) return null;
@@ -43,7 +60,12 @@ function extractFirstJson(text: string): any | null {
   }
 }
 
-/** Get plain text from an AIMessage-ish result. */
+/**
+ * Get plain text from an AIMessage-like result.
+ *
+ * @param res - LangChain AIMessage or similar object.
+ * @returns Extracted text content.
+ */
 function toText(res: any): string {
   const c = res?.content;
   if (typeof c === "string") return c;
@@ -60,9 +82,10 @@ function toText(res: any): string {
 /**
  * Generate a short, personable intro response with one follow-up question.
  *
- * @param userMessage The visitor's message (intro/hiring style).
- * @param systemPolicy Your base system content (values, boundaries, etc).
- * @param caps Length/temperature caps; numPredict is derived from max_tokens.
+ * @param userMessage - The visitor's message (intro/hiring style).
+ * @param systemPolicy - Base system content (values, boundaries, etc).
+ * @param caps - Length/temperature caps; numPredict derived from max_tokens.
+ * @returns Intro answer string.
  */
 export async function generateIntroAnswer(
   userMessage: string,

--- a/src/ingest-worker.ts
+++ b/src/ingest-worker.ts
@@ -31,10 +31,19 @@ const EMBEDDING_DIM = Number(process.env.EMBEDDING_DIM || 768);
 const qdrant = new QdrantClient({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
 const UUID_NS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 
+/**
+ * Compute a SHA-256 hex hash of a string.
+ *
+ * @param s - String to hash.
+ * @returns Hex digest of the hash.
+ */
 function sha256(s: string): string {
   return createHash("sha256").update(s).digest("hex");
 }
 
+/**
+ * Ensure the target Qdrant collection exists, creating it if needed.
+ */
 async function ensureCollection(): Promise<void> {
   try {
     await qdrant.getCollection(COLLECTION);
@@ -46,6 +55,12 @@ async function ensureCollection(): Promise<void> {
   }
 }
 
+/**
+ * Embed a batch of texts concurrently using Ollama.
+ *
+ * @param texts - Text strings to embed.
+ * @returns Array of embedding vectors.
+ */
 async function embedBatch(texts: string[]): Promise<number[][]> {
   const P = 6;
   const results: number[][] = new Array(texts.length);
@@ -77,6 +92,13 @@ async function embedBatch(texts: string[]): Promise<number[][]> {
   return results;
 }
 
+/**
+ * Upsert a batch of vectors and payloads into Qdrant.
+ *
+ * @param docId - Logical document identifier.
+ * @param chunks - Chunk metadata array.
+ * @param vectors - Corresponding embedding vectors.
+ */
 async function upsertBatch(
   docId: string,
   chunks: RagChunk[],
@@ -107,6 +129,12 @@ async function upsertBatch(
   });
 }
 
+/**
+ * Ingest a markdown file into Qdrant by embedding and upserting chunks.
+ *
+ * @param path - Path to the markdown file.
+ * @param docId - Optional logical document id (defaults to path).
+ */
 export async function ingestFile(path: string, docId = path): Promise<void> {
   await ensureCollection();
 

--- a/src/router/hybrid.ts
+++ b/src/router/hybrid.ts
@@ -4,7 +4,12 @@
 
 import type { Intent } from "../utils/intent";
 
-/** Retrieval on/off per intent. */
+/**
+ * Determine whether semantic retrieval should occur for a given intent.
+ *
+ * @param intent - Intent predicted for the user's message.
+ * @returns `true` if retrieval should be performed.
+ */
 export function shouldRetrieve(intent: Intent): boolean {
   return (
     intent === "profile_specific" ||
@@ -13,7 +18,12 @@ export function shouldRetrieve(intent: Intent): boolean {
   );
 }
 
-/** Short-answer clamp per intent. */
+/**
+ * Check if a response for the intent should be clamped to a short answer.
+ *
+ * @param intent - Intent predicted for the user's message.
+ * @returns `true` for short-answer intents.
+ */
 export function isShortIntent(intent: Intent): boolean {
   return intent === "small_talk" || intent === "profile_basic";
 }

--- a/src/schema/graphql.ts
+++ b/src/schema/graphql.ts
@@ -27,7 +27,11 @@ const schema = /* GraphQL */ `
 
 let __SYSTEM_CACHE__: string | null = null;
 
-/** Load system content and append answer policies if present. */
+/**
+ * Load system content and append answer policies if present.
+ *
+ * @returns Combined system prompt string.
+ */
 async function getSystemContent(): Promise<string> {
   if (__SYSTEM_CACHE__) return __SYSTEM_CACHE__;
 
@@ -63,7 +67,12 @@ async function getSystemContent(): Promise<string> {
   return __SYSTEM_CACHE__;
 }
 
-/** Remove dataset labels the model may echo (Prompt/Target/Q/A/Follow-up). */
+/**
+ * Remove dataset labels the model may echo (Prompt/Target/Q/A/Follow-up).
+ *
+ * @param s - Raw model output.
+ * @returns Sanitized output string.
+ */
 function sanitizeOutput(s: string): string {
   return s
     .replace(
@@ -74,12 +83,23 @@ function sanitizeOutput(s: string): string {
     .trim();
 }
 
-/** Return the first N sentences from a blob of text. */
+/**
+ * Return the first N sentences from a blob of text.
+ *
+ * @param s - Input text.
+ * @param n - Maximum number of sentences.
+ * @returns Truncated text containing at most N sentences.
+ */
 function firstNSentences(s: string, n: number): string {
   const parts = s.replace(/\s+/g, " ").split(/(?<=[.!?])\s/);
   return parts.slice(0, n).join(" ");
 }
 
+/**
+ * Create and configure the Fastify GraphQL application.
+ *
+ * @returns Configured Fastify instance.
+ */
 export async function createApp() {
   const app = Fastify({ logger: false });
   initVectorStore(process.env.QDRANT_URL!, process.env.QDRANT_API_KEY!);

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -25,7 +25,12 @@ export type LlmCaps = {
 const OLLAMA = process.env.OLLAMA_URL || "http://127.0.0.1:11434";
 const CHAT_MODEL = process.env.CHAT_MODEL || "mistral:7b-instruct-q4_K_M";
 
-/** Convert your OpenAI-style messages into LangChain message objects. */
+/**
+ * Convert OpenAI-style messages into LangChain message objects.
+ *
+ * @param messages - Array of OpenAI-format messages.
+ * @returns Array of LangChain message instances.
+ */
 function toLcMessages(
   messages: Array<{ role: "system" | "user" | "assistant"; content: string }>
 ): BaseMessage[] {
@@ -41,7 +46,12 @@ function toLcMessages(
   });
 }
 
-/** Extract plain text from a LangChain AIMessage result. */
+/**
+ * Extract plain text from a LangChain AIMessage result.
+ *
+ * @param res - LangChain AIMessage or compatible object.
+ * @returns Trimmed text content.
+ */
 function toText(res: { content: unknown }): string {
   const c = (res as any).content;
   if (typeof c === "string") return c.trim();
@@ -60,8 +70,9 @@ function toText(res: { content: unknown }): string {
 /**
  * Chat via LangChain + Ollama and return the whole reply as a string.
  *
- * @param messages OpenAI-style messages (system/user/assistant).
- * @param caps     Controls temperature and length.
+ * @param messages - OpenAI-style messages (system/user/assistant).
+ * @param caps - Controls temperature and length.
+ * @returns Generated assistant reply.
  */
 export async function chatStream(
   messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,

--- a/src/services/vectorStore.ts
+++ b/src/services/vectorStore.ts
@@ -1,5 +1,5 @@
 /**
- * Qdrant vector store helpers for search.
+ * @file Qdrant vector store helpers for semantic search.
  * Works with your existing embed wrapper and envs.
  */
 
@@ -10,19 +10,30 @@ import { embed } from "./embeddings.js";
 let client: QdrantClient | null = null;
 let collection = process.env.QDRANT_COLLECTION || "chat_with_me";
 
-export function initVectorStore(url: string, apiKey: string) {
+/**
+ * Initialize the Qdrant client used by search helpers.
+ *
+ * @param url - Base URL of the Qdrant instance.
+ * @param apiKey - API key for the Qdrant instance.
+ */
+export function initVectorStore(url: string, apiKey: string): void {
   if (!client) client = new QdrantClient({ url, apiKey });
   collection = process.env.QDRANT_COLLECTION || collection;
 }
 
 /**
  * Basic semantic search with payload return.
- * No score threshold. Recall is preferred at this layer.
+ * Recall is preferred over precision at this layer.
+ *
+ * @param opts - Search parameters.
+ * @param opts.query - Text to search for.
+ * @param opts.topK - Number of results to return.
+ * @returns Array of Qdrant search hits.
  */
 export async function search(opts: {
   query: string;
   topK: number;
-}): Promise<Array<any>> {
+}): Promise<any[]> {
   if (!client)
     throw new Error("Qdrant client not initialized. Call initVectorStore()");
 
@@ -54,10 +65,17 @@ export async function search(opts: {
   return Array.isArray(res) ? res : [];
 }
 
+/**
+ * Run multiple searches and return a deduplicated list of hits.
+ *
+ * @param queries - Queries to issue against the vector store.
+ * @param topK - Results per query.
+ * @returns Combined array of unique search hits.
+ */
 export async function searchMany(
   queries: string[],
   topK = 4
-): Promise<Array<any>> {
+): Promise<any[]> {
   const all: any[] = [];
   const seen = new Set<string>();
   for (const q of queries) {

--- a/src/utils/intent.ts
+++ b/src/utils/intent.ts
@@ -10,12 +10,23 @@ export type Intent =
   | "deep_tech" // technical how/why questions
   | "hiring"; // recruiting / availability / rates
 
-/** Normalize input once. */
+/**
+ * Normalize input once for intent routing.
+ *
+ * @param s - String to normalize.
+ * @returns Lowercased and trimmed string.
+ */
 function norm(s: string): string {
   return (s || "").toLowerCase().trim();
 }
 
-/** Heuristics for each intent. Keep fast and readable. */
+/**
+ * Route a user message into a coarse intent.
+ * Keep heuristics fast and readable.
+ *
+ * @param message - Raw user message.
+ * @returns Predicted intent label.
+ */
 export function routeIntent(message: string): Intent {
   const m = norm(message);
 
@@ -62,7 +73,12 @@ export function routeIntent(message: string): Intent {
   return "small_talk";
 }
 
-/** Per-intent LLM and retrieval caps used by resolvers. */
+/**
+ * Per-intent LLM and retrieval caps used by resolvers.
+ *
+ * @param intent - Intent label from {@link routeIntent}.
+ * @returns Object with LLM caps and retrieval depth.
+ */
 export function intentParams(intent: Intent): {
   llm: { max_tokens: number; temperature: number };
   topK: number;
@@ -82,7 +98,12 @@ export function intentParams(intent: Intent): {
   }
 }
 
-/** Per-intent tone/constraints appended in the system prompt. */
+/**
+ * Per-intent tone and constraints appended in the system prompt.
+ *
+ * @param intent - Intent label from {@link routeIntent}.
+ * @returns Style guidance string.
+ */
 export function styleInstruction(intent: Intent): string {
   switch (intent) {
     case "profile_basic":

--- a/src/utils/retrieval.ts
+++ b/src/utils/retrieval.ts
@@ -1,11 +1,16 @@
 /**
- * Retrieval policy utilities.
+ * @file Retrieval policy utilities.
  * Adds light rerank using section and question payloads when present.
  */
 
 import { search, searchMany } from "../services/vectorStore";
 
-/** Detect if user wants a personal fact. */
+/**
+ * Detect if the user is asking for personal facts.
+ *
+ * @param message - User message.
+ * @returns `true` when the text implies a personal fact request.
+ */
 function wantsPersonalFacts(message: string): boolean {
   const m = (message || "").toLowerCase();
   return (
@@ -32,13 +37,23 @@ const PERSONAL_NOUNS = [
   "meal",
 ];
 
-/** Pull candidate keywords from the message. */
+/**
+ * Pull candidate personal keywords from the message.
+ *
+ * @param message - User message.
+ * @returns Array of keywords appearing in the message.
+ */
 function derivePersonalKeywords(message: string): string[] {
   const m = (message || "").toLowerCase();
   return PERSONAL_NOUNS.filter((n) => m.includes(n));
 }
 
-/** Default filter to drop personal noise for tech asks. */
+/**
+ * Default filter to drop personal trivia for technical questions.
+ *
+ * @param line - Text line from a document.
+ * @returns `true` if the line is considered personal noise.
+ */
 function isPersonalNoiseLine(line: string): boolean {
   return (
     /\bFavorite\s+(band|dog|music|color|teams?)\b/i.test(line) ||
@@ -47,7 +62,13 @@ function isPersonalNoiseLine(line: string): boolean {
   );
 }
 
-/** Prefer lines that look like specific favorite facts. */
+/**
+ * Extract lines that appear to contain specific favorite facts.
+ *
+ * @param text - Text blob to scan.
+ * @param keywords - Candidate personal keywords.
+ * @returns Array of lines mentioning favorites.
+ */
 function extractFavoriteLines(text: string, keywords: string[]): string[] {
   const lines = text
     .split(/\r?\n/)
@@ -65,7 +86,12 @@ function extractFavoriteLines(text: string, keywords: string[]): string[] {
   return hits;
 }
 
-/** Deduplicate while preserving order. */
+/**
+ * Deduplicate values while preserving their original order.
+ *
+ * @param arr - Array of values.
+ * @returns Array with duplicates removed.
+ */
 function uniq<T>(arr: T[]): T[] {
   const seen = new Set<string>();
   const out: T[] = [];
@@ -81,7 +107,11 @@ function uniq<T>(arr: T[]): T[] {
 
 /**
  * Build a context block by retrieving topK snippets for the user message.
- * Light rerank will boost exact matches on payload.question and section intent.
+ * Light rerank boosts exact matches on payload.question and section intent.
+ *
+ * @param message - User message to ground against.
+ * @param topK - Number of snippets to retrieve.
+ * @returns Combined context string.
  */
 export async function buildContext(
   message: string,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,5 +1,5 @@
 /**
- * Split markdown for RAG.
+ * @file Utilities for splitting markdown into RAG-friendly chunks.
  * Each Q with its A is one chunk.
  * Each H2 or H3 defines a section anchor.
  * Long sections are soft wrapped with overlap.
@@ -15,10 +15,22 @@ export type RagChunk = {
 const MAX_CHARS = 3500; // about 900 tokens
 const OVERLAP = 200;
 
-function clean(s: string) {
+/**
+ * Trim trailing whitespace from lines and collapse blank lines.
+ *
+ * @param s - String to clean.
+ * @returns Cleaned string.
+ */
+function clean(s: string): string {
   return s.replace(/[ \t]+\n/g, "\n").trim();
 }
 
+/**
+ * Split a markdown document into overlapping RAG chunks.
+ *
+ * @param md - Markdown source text.
+ * @returns Array of chunk objects with section metadata.
+ */
 export function splitMarkdownForRAG(md: string): RagChunk[] {
   const lines = md.split("\n");
   const out: RagChunk[] = [];


### PR DESCRIPTION
## Summary
- add consistent TSDoc comments across services, utilities, and routers
- document retrieval and ingestion helpers
- improve inline documentation for LLM and vector store wrappers

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Cannot find module 'mercurius' or its corresponding type declarations)

------
https://chatgpt.com/codex/tasks/task_e_689fca1602908326be4b5052dcb30964