### PR TITLE
Reduce RAG chunk size

### DIFF
--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -12,8 +12,8 @@ export type RagChunk = {
   order: number;
 };
 
-const MAX_CHARS = 3500; // about 900 tokens
-const OVERLAP = 200;
+const MAX_CHARS = 1000; // about 250 tokens
+const OVERLAP = 100;
 
 /**
  * Trim trailing whitespace from lines and collapse blank lines.


### PR DESCRIPTION
## Summary
- lower RAG chunk size to ~1k chars with smaller overlap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run ingest:jesse` *(fails: connect ENETUNREACH to Qdrant)*
- `node dist/utils/retrieval.js` favorite dog query *(fails: connect ECONNREFUSED 127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_68a29d9ef8e8832696b221cc1bd4a78e