### PR TITLE
Log Qdrant collection during API startup

### DIFF
--- a/src/services/vectorStore.ts
+++ b/src/services/vectorStore.ts
@@ -19,6 +19,7 @@ let collection = process.env.QDRANT_COLLECTION || "chat_with_me";
 export function initVectorStore(url: string, apiKey: string): void {
   if (!client) client = new QdrantClient({ url, apiKey });
   collection = process.env.QDRANT_COLLECTION || collection;
+  console.log(`Using Qdrant collection: ${collection}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Log the active Qdrant collection during vector store initialization for easier runtime verification

## Testing
- `npm run build`
- `QDRANT_URL=http://localhost:6333 QDRANT_API_KEY=none QDRANT_COLLECTION=chat_with_me node dist/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a29d9fdcc483268cd743bcf7279c2a