### PR TITLE
Log sanitized chat output and refine label filtering

### DIFF
--- a/src/schema/graphql.ts
+++ b/src/schema/graphql.ts
@@ -76,7 +76,7 @@ async function getSystemContent(): Promise<string> {
 function sanitizeOutput(s: string): string {
   return s
     .replace(
-      /^\s*\*{0,2}\s*(Prompt|Question|Target|Answer|Q|A|Follow[-\s]?up)\s*\*{0,2}\s*[:：]\s*/gim,
+      /^\s*\*{0,2}\s*(Prompt|Question|Target|Q|A|Follow[-\s]?up)\s*\*{0,2}\s*[:：]\s*/gim,
       ""
     )
     .replace(/^\s*[-•]\s*/gm, "")
@@ -148,6 +148,8 @@ export async function createApp() {
         const finalText = isShortIntent(intent)
           ? firstNSentences(stripped, 3)
           : stripped;
+
+        console.log({ raw, stripped, finalText });
 
         return finalText || "I don’t know.";
       },


### PR DESCRIPTION
## Summary
- Temporarily log the raw LLM output, sanitized text, and final response for debugging
- Tweak sanitize regex to avoid stripping answers prefixed with `Answer:`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'zod' or its type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bf80b2848326bc812f401cf0295d