### PR TITLE
refactor: include context in system message

### DIFF
--- a/src/schema/graphql.ts
+++ b/src/schema/graphql.ts
@@ -131,13 +131,11 @@ export async function createApp() {
 
         // 5) Messages for other intents
         const messages = [
-          { role: "system", content: sys },
           {
-            role: "user",
-            content: ctx
-              ? `Use only the context to answer. If it is not in the context, say I don’t know.\n\nContext:\n${ctx}\n\nQuestion:\n${message}`
-              : message,
+            role: "system",
+            content: ctx ? `${sys}\n\nContext:\n${ctx}` : sys,
           },
+          { role: "user", content: message },
         ] as const;
 
         // 6) Model call


### PR DESCRIPTION
## Summary
- append retrieved context to system message in chat resolver
- send original question without extra context instructions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3594219f08326b4a515920e54383e